### PR TITLE
USBH HUB: Fix port reset/enable masks

### DIFF
--- a/Library/UsbHostLib/src_core/hub.c
+++ b/Library/UsbHostLib/src_core/hub.c
@@ -439,7 +439,7 @@ static int do_port_reset(HUB_DEV_T *hub, int port)
             if (((wPortStatus & PORT_S_CONNECTION) == 0) ||
                     ((wPortStatus & (PORT_S_CONNECTION | PORT_S_ENABLE)) == (PORT_S_CONNECTION | PORT_S_ENABLE)))
             {
-                clear_port_feature(hub, PORT_C_ENABLE, port); /* clear port enable change */
+                clear_port_feature(hub, FS_C_PORT_ENABLE, port); /* clear port enable change */
                 return USBH_OK;
             }
         }
@@ -564,7 +564,7 @@ static int  port_status_change(HUB_DEV_T *hub, int port)
             return ret;                     /* class command failed                       */
     }
 
-    if (wPortChange & FS_C_PORT_RESET)     /* have port reset change?                     */
+    if (wPortChange & PORT_C_RESET)     /* have port reset change?                     */
     {
         ret = clear_port_feature(hub, FS_C_PORT_RESET, port);        /* clear port change */
         if (ret < 0)


### PR DESCRIPTION
I had issues with devices downstream of USB hubs. The device would not send data to interrupt pipes.

I discovered an error in the port status change mask which resolved the issue.

