### PR TITLE
USBH HID: Fix memory leak on failed interrupt write

### DIFF
--- a/Library/UsbHostLib/src_hid/hid_core.c
+++ b/Library/UsbHostLib/src_hid/hid_core.c
@@ -607,6 +607,7 @@ int32_t usbh_hid_start_int_write(HID_DEV_T *hdev, uint8_t ep_addr, HID_IW_FUNC *
     if (ret < 0)
     {
         HID_DBGMSG("Error - failed to submit interrupt read request (%d)", ret);
+        usbh_free_mem(utr->buff, utr->data_len);
         free_utr(utr);
         return HID_RET_IO_ERR;
     }


### PR DESCRIPTION
If the interrupt write fails, we clear the utr, but not the utr->buff. This is correct in all other places in the HID driver but not here.