### PR TITLE
USBH: Fix utr running checks in hid

### DIFF
--- a/Library/UsbHostLib/src_hid/hid_core.c
+++ b/Library/UsbHostLib/src_hid/hid_core.c
@@ -425,15 +425,6 @@ int32_t usbh_hid_start_int_read(HID_DEV_T *hdev, uint8_t ep_addr, HID_IR_FUNC *f
     if (!func)
         return HID_RET_INVALID_PARAMETER;
 
-    for (i = 0; i < CONFIG_HID_DEV_MAX_PIPE; i++)
-    {
-        utr = hdev->utr_list[i];
-        if ((utr != NULL) && (utr->ep != NULL) && (utr->ep->bEndpointAddress == ep_addr))
-        {
-            return HID_RET_XFER_IS_RUNNING;      /* transfer of this pipe is running      */
-        }
-    }
-
     if (ep_addr == 0)
         ep = usbh_iface_find_ep(iface, 0, EP_ADDR_DIR_IN | EP_ATTR_TT_INT);
     else
@@ -441,6 +432,15 @@ int32_t usbh_hid_start_int_read(HID_DEV_T *hdev, uint8_t ep_addr, HID_IR_FUNC *f
 
     if (ep == NULL)
         return USBH_ERR_EP_NOT_FOUND;
+
+    for (i = 0; i < CONFIG_HID_DEV_MAX_PIPE; i++)
+    {
+        utr = hdev->utr_list[i];
+        if ((utr != NULL) && (utr->ep != NULL) && (utr->ep->bEndpointAddress == ep->bEndpointAddress))
+        {
+            return HID_RET_XFER_IS_RUNNING;      /* transfer of this pipe is running      */
+        }
+    }
 
     utr = alloc_utr(iface->udev);
     if (!utr)
@@ -564,15 +564,6 @@ int32_t usbh_hid_start_int_write(HID_DEV_T *hdev, uint8_t ep_addr, HID_IW_FUNC *
     if (!func)
         return HID_RET_INVALID_PARAMETER;
 
-    for (i = 0; i < CONFIG_HID_DEV_MAX_PIPE; i++)
-    {
-        utr = hdev->utr_list[i];
-        if ((utr != NULL) && (utr->ep != NULL) && (utr->ep->bEndpointAddress == ep_addr))
-        {
-            return HID_RET_XFER_IS_RUNNING;      /* transfer of this pipe is running      */
-        }
-    }
-
     if (ep_addr == 0)
         ep = usbh_iface_find_ep(iface, 0, EP_ADDR_DIR_OUT | EP_ATTR_TT_INT);
     else
@@ -580,6 +571,15 @@ int32_t usbh_hid_start_int_write(HID_DEV_T *hdev, uint8_t ep_addr, HID_IW_FUNC *
 
     if (ep == NULL)
         return USBH_ERR_EP_NOT_FOUND;
+
+    for (i = 0; i < CONFIG_HID_DEV_MAX_PIPE; i++)
+    {
+        utr = hdev->utr_list[i];
+        if ((utr != NULL) && (utr->ep != NULL) && (utr->ep->bEndpointAddress == ep->bEndpointAddress))
+        {
+            return HID_RET_XFER_IS_RUNNING;      /* transfer of this pipe is running      */
+        }
+    }
 
     utr = alloc_utr(iface->udev);
     if (!utr)


### PR DESCRIPTION
The interrupt read and write functions attempt to check if a transfer is already running on that endpoint.

If the user specified 0 for an endpoint the function automatically finds the first suitable endpoint.

The check if a transfer is already running on that endpoint occurs before this happens so will never work if the user passes an endpoint of 0.