### PR TITLE
USBH: Prevent use of unitialised pointer

### DIFF
--- a/Library/UsbHostLib/src_core/hub.c
+++ b/Library/UsbHostLib/src_core/hub.c
@@ -213,7 +213,7 @@ int hub_probe(IFACE_T *iface)
 {
     UDEV_T      *udev = iface->udev;
     ALT_IFACE_T *aif = iface->aif;
-    EP_INFO_T   *ep;
+    EP_INFO_T   *ep = NULL;
     HUB_DEV_T   *hub;
     UTR_T       *utr;
     uint32_t    read_len;

--- a/Library/UsbHostLib/src_hid/hid_driver.c
+++ b/Library/UsbHostLib/src_hid/hid_driver.c
@@ -54,7 +54,7 @@ static int hid_probe(IFACE_T *iface)
     UDEV_T       *udev = iface->udev;
     ALT_IFACE_T  *aif = iface->aif;
     DESC_IF_T    *ifd;
-    EP_INFO_T    *ep;
+    EP_INFO_T    *ep = NULL;
     HID_DEV_T    *hdev, *p;
     int          i;
 


### PR DESCRIPTION
These pointers are created on the stack but not set to a default value. If the stack is not zeroed this pointer will be a non-NULL garbage value or at best case considered indeterminate.

These can potentially be used unitiailised in these checks:
https://github.com/OpenNuvoton/N9H30_emWin_NonOS/blob/423de4fd36e92fddd99caa60bc13ea3656fb1c95/Library/UsbHostLib/src_core/hub.c#L241

and 

https://github.com/OpenNuvoton/N9H30_emWin_NonOS/blob/423de4fd36e92fddd99caa60bc13ea3656fb1c95/Library/UsbHostLib/src_hid/hid_driver.c#L82

Fix is to just initialised this to NULL.

The current code will throw warnings on more strict build configurations.